### PR TITLE
feat: add automatic backup for prd.json and progress.txt

### DIFF
--- a/PRD-PROMPT.md
+++ b/PRD-PROMPT.md
@@ -694,6 +694,20 @@ After generating `prd.json`, here's how it integrates with the autonomous coding
 | `PROMPT.md` | Instructions for the autonomous agent on how to work | Repository maintainer (rarely changes) |
 | `progress.txt` | Chronological log of completed work | Autonomous agent (appends after each task) |
 | `ralph_claude` | Shell script that runs the loop | Repository maintainer (rarely changes) |
+| `../.backup/` | Backup directory for prd.json and progress.txt | Automatic (created by ralph_claude before each iteration) |
+
+## Backup and Safety Features
+
+The Ralph Wiggum loop includes automatic backup functionality to protect against data loss:
+
+- **Before each iteration**, `prd.json` and `progress.txt` are backed up to `../.backup/`
+- Backup filenames include the iteration counter: `prd_iteration_1.json`, `progress_iteration_1.txt`, etc.
+- This prevents loss of critical data if the agent corrupts or clears these files
+- The agent is strictly instructed to:
+  - **Only modify the `passes` attribute** in `prd.json` (not add/delete/modify other fields)
+  - **Only append to `progress.txt`** (never overwrite or clear it)
+  - **Never create temporary progress_*.txt files** (use only the main progress.txt)
+  - **Clean up any temporary files** before committing
 
 ## What Happens After You Generate the PRD
 

--- a/PROMPT.md
+++ b/PROMPT.md
@@ -19,6 +19,25 @@ You are an expert software engineer working on a feature backlog. Your task is t
 - **UPDATE THE PRD**: Mark completed items as done in `prd.json`
 - **Quality First**: Type checking and tests must pass
 
+## Critical File Handling Rules
+
+### PRD.json Modifications
+- **ONLY modify the `passes` attribute** in `prd.json`
+- **DO NOT add, delete, or modify any other fields** (category, description, steps, etc.)
+- **DO NOT reorder items** in the PRD
+- **DO NOT create or modify any fields** except setting `passes: false` to `passes: true`
+
+### Progress.txt Handling
+- **ONLY APPEND** to `progress.txt` - never overwrite or clear it
+- **DO NOT create temporary progress files** like `progress_featurename.txt`
+- If you need to draft progress notes, keep them in memory and append them to `progress.txt` in one operation
+- **NEVER leave temporary progress_*.txt files** in the codebase
+
+### Temporary File Cleanup
+- If you accidentally create any temporary files (progress_*.txt, etc.), **DELETE THEM IMMEDIATELY**
+- Before committing, verify no temporary files exist: `git status` should show only intended changes
+- Remove temporary files using `git rm` if they were accidentally added
+
 ## When Complete
 
 If you determine the PRD is fully complete, output `<promise>COMPLETE</promise>` to signal the loop to exit.

--- a/PROMPT_TEMPLATES.md
+++ b/PROMPT_TEMPLATES.md
@@ -26,6 +26,12 @@ CRITICAL RULES:
 - Make atomic git commits with conventional commit format (feat:, fix:, etc.)
 - When ALL tasks are complete, output exactly: <promise>COMPLETE</promise>
 - NEVER skip quality checks or commit without passing tests
+
+FILE HANDLING RULES (CRITICAL):
+- In prd.json: ONLY modify the "passes" attribute (never add/delete/modify items or other fields)
+- In progress.txt: ONLY APPEND (never overwrite or clear)
+- NEVER create temporary progress_*.txt files
+- Clean up any temporary files before committing
 ```
 
 ## User Prompt Template (Each Iteration)
@@ -43,10 +49,11 @@ Your instructions:
 3. After implementing, run your project's quality checks:
    - npm test / pytest / go test (as applicable)
    - Type checking if available
-4. Update the PRD: change the completed task's "passes" field from false to true
-5. Append a line to progress.txt documenting what you just completed
-6. Create a git commit: git add -A && git commit -m "feat: [task name]"
-7. Repeat: go back to step 1 until you encounter the <promise>COMPLETE</promise> marker
+4. Update the PRD: change ONLY the completed task's "passes" field from false to true (DO NOT modify any other fields)
+5. Append a line to progress.txt documenting what you just completed (DO NOT overwrite, only append)
+6. Clean up any temporary files (DO NOT leave progress_*.txt or other temp files)
+7. Create a git commit: git add -A && git commit -m "feat: [task name]"
+8. Repeat: go back to step 1 until you encounter the <promise>COMPLETE</promise> marker
 
 If something fails:
 - Debug the error
@@ -87,6 +94,31 @@ Keep progress.txt:
 - One line per completed task
 - Include: timestamp, task name, status
 - Document failures or obstacles
+
+## Backup and Safety
+
+The Ralph Wiggum loop includes automatic backup functionality:
+
+- Before each iteration, `prd.json` and `progress.txt` are automatically backed up to `../.backup/`
+- Backup filenames include the iteration counter: `prd_iteration_1.json`, `progress_iteration_1.txt`, etc.
+- This protects against accidental corruption or deletion of critical files
+- If the agent corrupts these files, you can restore from the most recent backup
+
+To implement this in your own loop script:
+
+```bash
+# At the start of each iteration
+BACKUP_DIR="../.backup"
+mkdir -p "$BACKUP_DIR"
+
+if [ -f "prd.json" ]; then
+    cp "prd.json" "$BACKUP_DIR/prd_iteration_${iteration_number}.json"
+fi
+
+if [ -f "progress.txt" ]; then
+    cp "progress.txt" "$BACKUP_DIR/progress_iteration_${iteration_number}.txt"
+fi
+```
 
 ## Common Issues & Solutions
 

--- a/README.md
+++ b/README.md
@@ -94,11 +94,19 @@ For other AI agents (GPT, Gemini, etc.), see `PROMPT_TEMPLATES.md` for implement
 
 ## How It Works
 
-1. **Loop starts**: Agent reads `prd.json` and `progress.txt`
-2. **Task selection**: Agent picks highest-priority incomplete task
-3. **Implementation**: Agent completes the task, runs tests, makes commit
-4. **Progress update**: Agent updates `prd.json` and appends to `progress.txt`
-5. **Repeat**: Loop continues until all tasks complete or max iterations reached
+1. **Backup**: Before each iteration, `prd.json` and `progress.txt` are backed up to `../.backup/` with iteration counter in filename
+2. **Loop starts**: Agent reads `prd.json` and `progress.txt`
+3. **Task selection**: Agent picks highest-priority incomplete task
+4. **Implementation**: Agent completes the task, runs tests, makes commit
+5. **Progress update**: Agent updates `prd.json` (only the `passes` field) and appends to `progress.txt`
+6. **Repeat**: Loop continues until all tasks complete or max iterations reached
+
+### Safety Features
+
+- **Automatic backups**: `prd.json` and `progress.txt` are backed up before each iteration to `../.backup/prd_iteration_N.json` and `../.backup/progress_iteration_N.txt`
+- **Restricted modifications**: The agent can only change the `passes` attribute in `prd.json`, preventing accidental corruption
+- **Append-only progress**: `progress.txt` is append-only to preserve history
+- **No temporary files**: The agent is instructed not to create temporary `progress_*.txt` files
 
 ## Files and Templates
 

--- a/ralph_claude
+++ b/ralph_claude
@@ -25,6 +25,20 @@ for ((i=1; i<=$1; i++)); do
     echo "Iteration $i"
     echo "=========================================="
 
+    # Backup prd.json and progress.txt before iteration
+    BACKUP_DIR="../.backup"
+    mkdir -p "$BACKUP_DIR"
+
+    if [ -f "$PRD_FILE" ]; then
+        cp "$PRD_FILE" "$BACKUP_DIR/prd_iteration_${i}.json"
+        echo "Backed up prd.json to $BACKUP_DIR/prd_iteration_${i}.json"
+    fi
+
+    if [ -f "$PROGRESS_FILE" ]; then
+        cp "$PROGRESS_FILE" "$BACKUP_DIR/progress_iteration_${i}.txt"
+        echo "Backed up progress.txt to $BACKUP_DIR/progress_iteration_${i}.txt"
+    fi
+
     result=$(claude --permission-mode acceptEdits -p "$PROMPT_FILE" @progress.txt)
 
     # 1. Find the highest-priority feature to work on and work only on that feature.


### PR DESCRIPTION
Implements automatic backup functionality and strict file handling rules to prevent data loss.

## Changes
- Automatic backup of prd.json and progress.txt before each iteration to ../.backup/
- Backup filenames include iteration counter for easy restoration
- Strict file handling rules added to PROMPT.md (only modify passes attribute, only append to progress.txt)
- No temporary progress_*.txt files allowed
- Updated documentation across README.md, PRD-PROMPT.md, and PROMPT_TEMPLATES.md

Fixes #10

Generated with [Claude Code](https://claude.ai/code)