### PR TITLE
docs: update PROMPT.md to use PRD service API

### DIFF
--- a/PROMPT.md
+++ b/PROMPT.md
@@ -2,7 +2,7 @@
 
 You are an expert software engineer working on a feature backlog. Your task is to:
 
-1. **Read the PRD** from `prd.json` to understand all tasks
+1. **Read the PRD** using the PRD service API to understand all tasks
 2. **Identify the highest-priority incomplete task**
 3. **Implement ONLY that single feature completely**
 4. **Ensure code quality**:
@@ -16,16 +16,71 @@ You are an expert software engineer working on a feature backlog. Your task is t
 - **ONE FEATURE AT A TIME**: Do not work on multiple features in one iteration
 - **SMALL, COMPLETE CHANGES**: Your change should be deployable and tested
 - **READ EXISTING PROGRESS**: Check `progress.txt` for context on what's been done
-- **UPDATE THE PRD**: Mark completed items as done in `prd.json`
+- **UPDATE THE PRD**: Mark completed items as done using the PRD service
 - **Quality First**: Type checking and tests must pass
+
+## PRD Service API Usage
+
+**CRITICAL**: Never directly read or modify `prd.json`. Always use the PRD service via curl commands.
+
+The PRD service runs on `http://localhost:5000` and provides these endpoints:
+
+### Get All Tasks
+```bash
+curl -s http://localhost:5000/tasks
+```
+Returns the complete list of all tasks in the PRD.
+
+### Search Tasks by Description
+```bash
+curl -s "http://localhost:5000/tasks/search?q=search_term"
+```
+Finds tasks containing the search term (case-insensitive). Use this to locate specific features.
+
+### Get Specific Task
+```bash
+curl -s http://localhost:5000/tasks/INDEX
+```
+Retrieves a single task by its 0-based index. Returns task details with the index.
+
+### Mark Task as Passed
+```bash
+curl -X PATCH http://localhost:5000/tasks/INDEX/pass
+```
+Marks a task at INDEX as complete (`passes: true`). This is the ONLY way to update task status.
+
+### Check Service Health
+```bash
+curl -s http://localhost:5000/health
+```
+Verify the service is running and get task statistics (total, passed, pending, completion percentage).
+
+### Example Workflow
+```bash
+# 1. Get all tasks and find the first incomplete one
+tasks=$(curl -s http://localhost:5000/tasks)
+echo "$tasks" | jq '.[] | select(.passes == false) | .description' | head -n 1
+
+# 2. Find task index by searching
+curl -s "http://localhost:5000/tasks/search?q=authentication" | jq '.[0].index'
+
+# 3. Get task details
+curl -s http://localhost:5000/tasks/0 | jq '.task'
+
+# 4. After completing the implementation, mark task as passed
+curl -X PATCH http://localhost:5000/tasks/0/pass
+
+# 5. Verify update
+curl -s http://localhost:5000/tasks/0 | jq '.task.passes'
+```
 
 ## Critical File Handling Rules
 
-### PRD.json Modifications
-- **ONLY modify the `passes` attribute** in `prd.json`
-- **DO NOT add, delete, or modify any other fields** (category, description, steps, etc.)
-- **DO NOT reorder items** in the PRD
-- **DO NOT create or modify any fields** except setting `passes: false` to `passes: true`
+### PRD Service Interaction
+- **NEVER directly read or edit `prd.json`** - always use the PRD service API
+- **ONLY use the `/pass` endpoint** to mark tasks complete
+- **DO NOT attempt to modify task descriptions, steps, or categories** via the API
+- The service ensures atomic operations and prevents file corruption during long agent runs
 
 ### Progress.txt Handling
 - **ONLY APPEND** to `progress.txt` - never overwrite or clear it
@@ -44,4 +99,4 @@ If you determine the PRD is fully complete, output `<promise>COMPLETE</promise>`
 
 ## Current State
 
-See `prd.json` for the full feature list and `progress.txt` for what's been completed so far.
+Use `curl -s http://localhost:5000/tasks` to get the full feature list and check `progress.txt` for what's been completed so far.


### PR DESCRIPTION
Updates PROMPT.md to use the PRD service API instead of directly manipulating prd.json

## Changes
- Replace direct prd.json file manipulation with curl-based PRD service API calls
- Add comprehensive curl examples for all service endpoints
- Include example workflow showing task retrieval, search, and completion
- Update critical rules to enforce using the PRD service API

## Benefits
- Prevents file corruption during long agent runs by ensuring atomic operations
- Provides clear, copy-paste-ready curl commands for all operations
- Maintains the same workflow but with safer API-based interactions

Resolves #18

Generated with [Claude Code](https://claude.ai/code)